### PR TITLE
Ability to pin to bundle install

### DIFF
--- a/roles/aap_setup_download/README.md
+++ b/roles/aap_setup_download/README.md
@@ -17,6 +17,7 @@ The following input variables are required:
 It has no default value and _must_ be defined.
 * `aap_setup_down_version` defines the minor version to download (e.g. `2.5`). Defaults to current latest `2.5` version.
 The default is the latest version available at time of writing.
+* `aap_setup_down_version_patch` defines the patch version to download (e.g `12`) Defaults to false which will always get latest.
 * `aap_setup_down_dest_dir` is the directory to where you want to download the tarball.
 It is by default the working directory `aap_setup_working_dir` also used by other roles of the collection, or ultimately `/var/tmp`.
 * `aap_setup_down_type` can be either `setup`, `setup-bundle`, `containerized-setup`, depending which flavour of the tarball you want to download.

--- a/roles/aap_setup_download/defaults/main.yml
+++ b/roles/aap_setup_download/defaults/main.yml
@@ -9,6 +9,9 @@
 # which version of the installer to download
 aap_setup_down_version: "2.5"
 
+# Which minor version to download, eg {{ aap_setup_down_version }}-12
+aap_setup_down_version_minor: false  # set to false to download the latest version, 12 for 2.5-12
+
 # Which system architecture to dowload for
 aap_setup_arch: x86_64
 

--- a/roles/aap_setup_download/defaults/main.yml
+++ b/roles/aap_setup_download/defaults/main.yml
@@ -10,9 +10,9 @@
 aap_setup_down_version: "2.5"
 
 # Which minor version to download, eg {{ aap_setup_down_version }}-12
-aap_setup_down_version_minor: false  # set to false to download the latest version, 12 for 2.5-12
+aap_setup_down_version_patch: false  # set to false to download the latest version, 12 for 2.5-12
 
-# Which system architecture to dowload for
+# Which system architecture to download for
 aap_setup_arch: x86_64
 
 # Which RHEL version are you using (8 or 9)

--- a/roles/aap_setup_download/tasks/main.yml
+++ b/roles/aap_setup_download/tasks/main.yml
@@ -33,8 +33,8 @@
 - name: Filter the desired image based on filename
   ansible.builtin.set_fact:
     __aap_filtered_version_selected: >-
-      {{ __aap_setup_down_images | selectattr('filename', 'search', (aap_setup_down_version | string) + '-' + (aap_setup_down_version_minor | string)) | list }}
-  when: aap_setup_down_version_minor
+      {{ __aap_setup_down_images | selectattr('filename', 'search', (aap_setup_down_version | string) + '-' + (aap_setup_down_version_patch | string)) | list }}
+  when: aap_setup_down_version_patch is defined
 
 - name: Set the image to download, filtered or latest
   ansible.builtin.set_fact:
@@ -49,7 +49,7 @@
   ansible.builtin.pause:
     prompt: |
      ########################################################################################
-      The selected version ({{ __aap_image_to_download.filename }}) is not the latest version
+      The selected version {{ __aap_image_to_download.filename }} is not the latest version
       The latest version is: {{ __aap_setup_down_images[0].filename }}
      ########################################################################################
     seconds: 5

--- a/roles/aap_setup_download/tasks/main.yml
+++ b/roles/aap_setup_download/tasks/main.yml
@@ -26,10 +26,39 @@
       'ansible-automation-platform-setup'))) | sort(attribute='datePublished', reverse=True) | selectattr('filename', 'search', (aap_setup_down_type | string) + '-'
       + (aap_setup_down_version | string)) }}"
 
+- name: Display all the filenames available for download
+  ansible.builtin.debug:
+    msg: "{{ __aap_setup_down_images | map(attribute='filename') | list }}"
+
+- name: Filter the desired image based on filename
+  ansible.builtin.set_fact:
+    __aap_filtered_version_selected: >-
+      {{ __aap_setup_down_images | selectattr('filename', 'search', (aap_setup_down_version | string) + '-' + (aap_setup_down_version_minor | string)) | list }}
+  when: aap_setup_down_version_minor
+
+- name: Set the image to download, filtered or latest
+  ansible.builtin.set_fact:
+    __aap_image_to_download: >-
+      {{ (__aap_filtered_version_selected | length > 0) | ternary(__aap_filtered_version_selected[0], __aap_setup_down_images[0]) }}
+
+- name: Check if the selected version is the latest
+  ansible.builtin.set_fact:
+    is_latest_version: "{{ __aap_image_to_download.filename == __aap_setup_down_images[0].filename }}"
+
+- name: Notify if the selected version is not the latest
+  ansible.builtin.pause:
+    prompt: |
+     ########################################################################################
+      The selected version ({{ __aap_image_to_download.filename }}) is not the latest version
+      The latest version is: {{ __aap_setup_down_images[0].filename }}
+     ########################################################################################
+    seconds: 5
+  when: not is_latest_version
+
 - name: Downloading the latest installer of type {{ aap_setup_down_type }}
   ansible.builtin.get_url:
-    url: "{{ __aap_setup_down_images[:3][0].downloadHref }}"
-    dest: "{{ aap_setup_down_dest_dir }}/{{ __aap_setup_down_images[:3][0].filename }}"
+    url: "{{ __aap_image_to_download.downloadHref }}"
+    dest: "{{ aap_setup_down_dest_dir }}/{{ __aap_image_to_download.filename }}"
     mode: "0644"
     headers:
       Authorization: Bearer {{ __aap_setup_down_login.json.access_token }}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Want the ability to pin to a patch version of the bundle so I know I'm always getting the same containers and code in higher environment deployments. If unset, the behaviour of the latest should be the same

# How should this be tested?

Have only tested with the bundled installer

# Is there a relevant Issue open for this?

N/A

# Other Relevant info, PRs, etc

-13 came out as well and the API says its there, but the package isn't.

```
 "HTTP Error 404: Not Found", "status_code": 404, "url": "https://api.access.redhat.com/management/v1/images/68b65fa55dc46e26cd20a9cbb6941d6a97bc6cc2fb4955aa7b4e51b26c120d61/download"
```

Displays this if you're behind in versions

```
[infra.aap_utilities.aap_setup_download : Notify if the selected version is not the latest]
########################################################################################
 The selected version ansible-automation-platform-containerized-setup-bundle-2.5-12-x86_64.tar.gz is not the latest version
 The latest version is: ansible-automation-platform-containerized-setup-bundle-2.5-13-x86_64.tar.gz
########################################################################################
```

